### PR TITLE
fix error message

### DIFF
--- a/internal/service/vmservice/delete.go
+++ b/internal/service/vmservice/delete.go
@@ -51,5 +51,5 @@ func DeleteVM(ctx context.Context, machineScope *scope.MachineScope) error {
 
 // VMNotFound checks if the given err is related to that the VM is not found in Proxmox.
 func VMNotFound(err error) bool {
-	return strings.Contains(err.Error(), "does not exist")
+	return strings.Contains(err.Error(), "cannot find vm with id")
 }

--- a/internal/service/vmservice/delete_test.go
+++ b/internal/service/vmservice/delete_test.go
@@ -36,7 +36,7 @@ func TestDeleteVM_SuccessNotFound(t *testing.T) {
 		Node:    "node1",
 	}, false)
 
-	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(nil, errors.New("vm does not exist: some reason")).Once()
+	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(nil, errors.New("cannot find vm with id")).Once()
 
 	require.NoError(t, DeleteVM(context.TODO(), machineScope))
 	require.Empty(t, machineScope.ProxmoxMachine.Finalizers)


### PR DESCRIPTION
## Fixed Proxmox machines not finalizing 

- [the following function](https://github.com/team-telnyx/cluster-api-provider-proxmox/blob/main/pkg/proxmox/goproxmox/api_client.go#L154) is used to call proxmox API to find a machine to delete. 
When is called with an invalid VMID it returns 
```
capmox-controller-manager-5d9cb7f5d9-j2n52 manager atl1-pc1-015
capmox-controller-manager-5d9cb7f5d9-j2n52 manager 500 Internal Server Error
```
It doesn't return the same as the api