### PR TITLE
accelerated scheduling

### DIFF
--- a/internal/service/scheduler/vmscheduler_test.go
+++ b/internal/service/scheduler/vmscheduler_test.go
@@ -94,3 +94,12 @@ func TestSelectNode(t *testing.T) {
 		require.Equal(t, expectMem, availableMem)
 	})
 }
+
+func TestDifference(t *testing.T) {
+	t.Run("Test Difference", func(t *testing.T) {
+		allowedNodes := []string{"pve1", "pve2", "pve3"}
+		acceleratedNodes := []string{"pve1", "pve2", "pve4"}
+		result := difference(allowedNodes, acceleratedNodes)
+		require.Equal(t, []string{"pve3"}, result)
+	})
+}


### PR DESCRIPTION
# "Smart" accelerated VM scheduling
Avoid scheduling accelerated machines in nodes where there are already other accelerated machines placed. This only consider k8s machines with the keyword `accelerated` in the machine name